### PR TITLE
Add Flask server and simple web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,54 @@
+# AI FHIR Backend
+
+This project contains a small example script that converts natural language
+queries into simulated FHIR API requests. It uses `spaCy` to extract
+simple entities like age, conditions and gender from the input text.
+
+## Setup
+
+Install the required dependencies and download the spaCy model:
+
+```bash
+pip install spacy flask
+python -m spacy download en_core_web_sm
+```
+
+## Running the script
+
+Run the program and enter a query when prompted:
+
+```bash
+python main.py
+```
+
+The script prints a simulated FHIR `Patient` search request based on the
+entities it finds in your query.
+
+## Running the web demo
+
+Start the Flask server in one terminal:
+
+```bash
+python server.py
+```
+
+Serve the static files in the `web` folder (for example on port 8000):
+
+```bash
+cd web
+python -m http.server 8000
+```
+
+Open `http://localhost:8000` in your browser. Enter a query in the text box
+and the generated FHIR request along with simulated patient results will be
+displayed in a table and bar chart.
+
+## Example mappings
+
+| Input text                                   | FHIR request                                   |
+|----------------------------------------------|------------------------------------------------|
+| `Show me all diabetic patients over 50`      | `/Patient?age=gt50&condition.code=diabetes`    |
+| `List hypertensive male patients over 40`    | `/Patient?age=gt40&gender=male&condition.code=hypertension` |
+| `Asthmatic female patients over 30`          | `/Patient?age=gt30&gender=female&condition.code=asthma` |
+| `Find male patients over 65 with diabetes`   | `/Patient?age=gt65&gender=male&condition.code=diabetes` |
+| `Patients over 20 with asthma or hypertension` | `/Patient?age=gt20&condition.code=asthma&condition.code=hypertension` |

--- a/server.py
+++ b/server.py
@@ -1,0 +1,33 @@
+from flask import Flask, request, jsonify
+from main import parse_query, build_fhir_request
+
+app = Flask(__name__)
+
+PATIENTS = [
+    {"name": "Alice", "age": 55, "gender": "female", "condition": "diabetes"},
+    {"name": "Bob", "age": 60, "gender": "male", "condition": "hypertension"},
+    {"name": "Carol", "age": 35, "gender": "female", "condition": "asthma"},
+    {"name": "Dave", "age": 70, "gender": "male", "condition": "diabetes"},
+]
+
+def filter_patients(age_gt, conditions, gender):
+    results = PATIENTS
+    if age_gt is not None:
+        results = [p for p in results if p["age"] > age_gt]
+    if gender:
+        results = [p for p in results if p["gender"] == gender]
+    if conditions:
+        results = [p for p in results if p["condition"] in conditions]
+    return results
+
+@app.route('/query', methods=['POST'])
+def query():
+    data = request.get_json(force=True)
+    text = data.get('text', '')
+    age_gt, conditions, gender = parse_query(text)
+    fhir_request = build_fhir_request(age_gt, conditions, gender)
+    patients = filter_patients(age_gt, conditions, gender)
+    return jsonify({'fhir_request': fhir_request, 'patients': patients})
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>FHIR Query UI</title>
+    <link rel="stylesheet" href="style.css">
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body>
+    <div id="container">
+        <h1>FHIR Query</h1>
+        <input type="text" id="queryInput" list="suggestions" placeholder="Enter query" />
+        <datalist id="suggestions">
+            <option value="Show me all diabetic patients over 50">
+            <option value="List hypertensive male patients over 40">
+            <option value="Asthmatic female patients over 30">
+        </datalist>
+        <button id="submitBtn">Submit</button>
+        <div id="output"></div>
+        <canvas id="chart" width="400" height="200"></canvas>
+        <table id="resultTable">
+            <thead>
+                <tr><th>Name</th><th>Age</th><th>Gender</th><th>Condition</th></tr>
+            </thead>
+            <tbody></tbody>
+        </table>
+    </div>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/web/script.js
+++ b/web/script.js
@@ -1,0 +1,45 @@
+async function submitQuery() {
+    const text = document.getElementById('queryInput').value;
+    const res = await fetch('http://localhost:5000/query', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text })
+    });
+    const data = await res.json();
+    document.getElementById('output').textContent = data.fhir_request;
+    updateTable(data.patients);
+    updateChart(data.patients);
+}
+
+document.getElementById('submitBtn').addEventListener('click', submitQuery);
+
+function updateTable(patients) {
+    const tbody = document.querySelector('#resultTable tbody');
+    tbody.innerHTML = '';
+    patients.forEach(p => {
+        const row = document.createElement('tr');
+        row.innerHTML = `<td>${p.name}</td><td>${p.age}</td><td>${p.gender}</td><td>${p.condition}</td>`;
+        tbody.appendChild(row);
+    });
+}
+
+let chart;
+function updateChart(patients) {
+    const ctx = document.getElementById('chart').getContext('2d');
+    const labels = patients.map(p => p.name);
+    const ages = patients.map(p => p.age);
+    if (chart) {
+        chart.destroy();
+    }
+    chart = new Chart(ctx, {
+        type: 'bar',
+        data: {
+            labels,
+            datasets: [{
+                label: 'Age',
+                data: ages,
+                backgroundColor: 'rgba(0,255,0,0.5)'
+            }]
+        }
+    });
+}

--- a/web/style.css
+++ b/web/style.css
@@ -1,0 +1,47 @@
+body {
+    background-color: #000;
+    color: #fff;
+    font-family: Arial, sans-serif;
+}
+
+#container {
+    max-width: 600px;
+    margin: 100px auto;
+    text-align: center;
+}
+
+input, button {
+    padding: 10px;
+    font-size: 16px;
+}
+
+input {
+    width: 80%;
+    color: #fff;
+    background-color: #222;
+    border: 1px solid #555;
+}
+
+button {
+    margin-top: 10px;
+}
+
+#output {
+    margin-top: 20px;
+    color: #0f0;
+}
+
+table {
+    width: 100%;
+    margin-top: 20px;
+    border-collapse: collapse;
+}
+
+th, td {
+    border: 1px solid #555;
+    padding: 5px;
+}
+
+canvas {
+    margin-top: 20px;
+}


### PR DESCRIPTION
## Summary
- create Flask API server for handling NLP queries and returning simulated FHIR results
- add `web` folder with HTML/CSS/JS for a minimal UI
- expose example patient data in server for chart/table display
- document how to run the server and web demo

## Testing
- `python -m py_compile main.py server.py`

------
https://chatgpt.com/codex/tasks/task_e_6844ae39d3cc8322bb94a48fbde22f71